### PR TITLE
Allow no sensor timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Let's review the configuration file (*config.json*):
 ```javascript
 {
     "debug": false,
-    "port": 4003,
+    "listener_port": 4003,
+    "port": 443,
     "username": "<your user>",
     "password": "<your password>",
     "root_url": "www.arcgis.com",
@@ -42,7 +43,8 @@ Let's review the configuration file (*config.json*):
                 ["median_speed", "esriFieldTypeDouble"],
                 ["occupancy", "esriFieldTypeDouble"],
                 ["trafficIntensity", "esriFieldTypeDouble"]
-            ]
+            ],
+            "whereClause":"id like 'urn:smartsantander:traffic:%'"
         },
 
         "lux" : {
@@ -57,7 +59,8 @@ Let's review the configuration file (*config.json*):
                 ["luminousFlux", "esriFieldTypeDouble"],
                 ["batteryCharge", "esriFieldTypeDouble"],
                 ["acceleration", "esriFieldTypeDouble"]
-            ]
+            ],
+            "whereClause":"id like 'urn:smartsantander:lux:%'"
         },
 
         "sound" : {
@@ -70,7 +73,8 @@ Let's review the configuration file (*config.json*):
                 ["Longitud", "esriFieldTypeDouble"],
                 ["sound", "esriFieldTypeDouble"],
                 ["batteryCharge", "esriFieldTypeDouble"]
-            ]
+            ],
+            "whereClause":"id like 'urn:smartsantander:sound:%'"
         },
 
         "soundacc" : {
@@ -84,7 +88,8 @@ Let's review the configuration file (*config.json*):
                 ["sound", "esriFieldTypeDouble"],
                 ["batteryCharge", "esriFieldTypeDouble"],
                 ["acceleration", "esriFieldTypeDouble"]
-            ]
+            ],
+            "whereClause":"id like 'urn:smartsantander:soundacc:%'"
         },
 
         "bus" : {
@@ -101,7 +106,8 @@ Let's review the configuration file (*config.json*):
                 ["speed", "esriFieldTypeDouble"],
                 ["status", "esriFieldTypeDouble"],
                 ["vehicle", "esriFieldTypeDouble"]
-            ]
+            ],
+            "whereClause":"id like 'urn:smartsantander:bus:%'"
         }
     }
 }
@@ -110,7 +116,8 @@ Let's review the configuration file (*config.json*):
 Let's see the configurations variables:
 
 * **debug**: *True/False* if we want to activate/desactivate the verbose mode.
-* **port**: Listening port
+* **listener_port**: Listening port
+* **port**: ArcGIS Online/Server port
 * **username**: nominal user
 * **password**: nominal user's password
 * **root_url**: *www.arcgis.com* if we want to user ArcGIS Online; or the url where the *Portal for ArcGIS* is located in case you want to use *ArcGIS Server*. It's neccesary to call the [*generateToken*](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Generate_Token/02r3000000m5000000/), [*isServiceNameAvailable*](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r300000076000000) and [*createService*](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r30000027r000000) methods
@@ -120,6 +127,7 @@ Let's see the configurations variables:
   * **serviceName**: name we want to use to host the data
   * **route**: path where the app is going to be listening
   * **fields**: it's an array of arrays with two elements: the attribute name and the field type
+  * **whereClause**: the "where clause" to identify each point of interrest (PoI) on ArcGIS. If fulfilled, the connector will execute the query and maintain internally a list of all existing PoIs on ArcGIS. Each sensor information will update the corresponding existing PoI. Otherwise, the connector inserts new PoI on ArcGIS.
 
 The next image shows where you will find the **services_url** and **account_id** values in ArcGIS Online:
 <img src="/docs/fiware_agol_params.png" style="width:100%">

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "debug": true,
-    "port": 4003,
+    "listener_port": "4003",
+    "port": 443,
     "username": "<tu usuario>",
     "password": "<tu password>",
     "root_url": "www.arcgis.com",
@@ -21,7 +22,8 @@
                 ["median_speed", "esriFieldTypeDouble"],
                 ["occupancy", "esriFieldTypeDouble"],
                 ["trafficIntensity", "esriFieldTypeDouble"]
-            ]
+            ],
+	    "whereClause":"id like 'urn:smartsantander:traffic:%'"
         },
 
         "lux" : {
@@ -36,7 +38,8 @@
                 ["luminousFlux", "esriFieldTypeDouble"],
                 ["batteryCharge", "esriFieldTypeDouble"],
                 ["acceleration", "esriFieldTypeDouble"]
-            ]
+            ],
+	    "whereClause":"id like 'urn:smartsantander:lux:%'"
         },
 
         "sound" : {
@@ -49,7 +52,8 @@
                 ["Longitud", "esriFieldTypeDouble"],
                 ["sound", "esriFieldTypeDouble"],
                 ["batteryCharge", "esriFieldTypeDouble"]
-            ]
+            ],
+	    "whereClause":"id like 'urn:smartsantander:sound:%'"
         },
 
         "soundacc" : {
@@ -63,7 +67,8 @@
                 ["sound", "esriFieldTypeDouble"],
                 ["batteryCharge", "esriFieldTypeDouble"],
                 ["acceleration", "esriFieldTypeDouble"]
-            ]
+            ],
+	    "whereClause":"id like 'urn:smartsantander:soundacc:%'"
         },
 
         "bus" : {
@@ -80,7 +85,8 @@
                 ["speed", "esriFieldTypeDouble"],
                 ["status", "esriFieldTypeDouble"],
                 ["vehicle", "esriFieldTypeDouble"]
-            ]
+            ],
+	    "whereClause":"id like 'urn:smartsantander:bus:%'"
         }
     }
 }

--- a/fiware_arcgis.js
+++ b/fiware_arcgis.js
@@ -256,11 +256,15 @@ var initFeatureService = function(sensor){
  *
  ************************************************************/
 
-// Method to transform sensor datetime format to ArcGIS datetime
+// Method to transform sensor datetime format to ArcGIS datetime, or return the now timestamp if no sensor datetime is present
 var parseDate = function(timeInstant){
     var date;
-    timeInstant = timeInstant.replace("-","/").replace("-","/").replace("T"," ");
-    date = new Date(timeInstant);
+    if(timeInstant){
+        timeInstant = timeInstant.replace("-","/").replace("-","/").replace("T"," ");
+        date = new Date(timeInstant);
+    }else{
+        date = new Date();//now
+    }
     return date.getTime();
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fiware_arcgis",
   "version": "1.5.0",
   "dependencies": {
-    "arc-node": "^0.2.9",
+    "arc-node": "^0.4.4",
     "arcgis-json-objects": "0.0.7",
     "body-parser": "~1.13.1",
     "express": "~4.13.0",


### PR DESCRIPTION
If no sensor timestamp data is available (TimeInstant field), a parse error is then rised (Cannot read property 'replace' of undefined). The fix allows to generate a timestamp value on thefly if not present from the sensor data.